### PR TITLE
JCWEB-134 Fix sticky panel fade on the Risk Disclosures page

### DIFF
--- a/apps/investor/src/pages/Invest/style.scss
+++ b/apps/investor/src/pages/Invest/style.scss
@@ -182,7 +182,7 @@
     top: -64px;
     left: 0;
     right: 0;
-    background: linear-gradient(0deg, $color-white, transparent);
+    background: linear-gradient(0deg, $color-white, rgba(255, 255, 255, 0.001));
   }
 }
 


### PR DESCRIPTION
In Safari `transparent` value has issue:
![image](https://user-images.githubusercontent.com/2114572/73361750-a2247200-42b6-11ea-9b2b-9bdd26122dbd.png)

Color have going to black.
